### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -7,7 +7,6 @@ class ItemsController < ApplicationController
   end
 
   def show
-
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,13 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!, except: [:index, :show]
+  before_action :set_item, only: [:show]
 
   def index
     @items = Item.all.order(created_at: 'DESC').includes(:user)
+  end
+
+  def show
+
   end
 
   def new

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -96,7 +96,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -21,7 +21,7 @@
         (税込) 送料込み
       </span>
     </div>
-    <% if Order.find_by(item_id: @item.id) == nil %>
+    <% if @item.order == nil? %>
       <% if user_signed_in? && current_user.id == @item.user.id %>
         <%= link_to '商品の編集', '#' , method: :get, class: "item-red-btn" %>
         <p class='or-text'>or</p>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -21,7 +21,7 @@
         (税込) 送料込み
       </span>
     </div>
-    <% if @item.order == nil? %>
+    <% if @item.order == nil %>
       <% if user_signed_in? && current_user.id == @item.user.id %>
         <%= link_to '商品の編集', '#' , method: :get, class: "item-red-btn" %>
         <p class='or-text'>or</p>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -18,7 +18,7 @@
         <%= "¥ #{@item.price}" %>
       </span>
       <span class="item-postage">
-        (税込) 送料込み
+        <%= @item.delivery_pay.name %>
       </span>
     </div>
     <% if @item.order == nil %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,69 +1,64 @@
 <%= render "shared/header" %>
 
-<%# 商品の概要 %>
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class='sold-out'>
-        <span>Sold Out!!</span>
-      </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
+      <% if Order.find_by(item_id: @item.id) %>
+        <div class='sold-out'>
+          <span>Sold Out!!</span>
+        </div>
+      <% end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= "¥ #{@item.price}" %>
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        (税込) 送料込み
       </span>
     </div>
-
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% if Order.find_by(item_id: @item.id) == nil %>
+      <% if user_signed_in? && current_user.id == @item.user.id %>
+        <%= link_to '商品の編集', '#' , method: :get, class: "item-red-btn" %>
+        <p class='or-text'>or</p>
+        <%= link_to '削除', '#', class:'item-destroy', method: :delete %>
+      <% elsif user_signed_in? %>
+          <%= link_to '購入画面に進む', item_purchases_path(@item) ,class:"item-red-btn"%>
+      <% end %>
+    <% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.explain %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.delivery_pay.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.delivery_area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.delivery_day.name %></td>
         </tr>
       </tbody>
     </table>
@@ -78,7 +73,6 @@
       </div>
     </div>
   </div>
-  <%# /商品の概要 %>
 
   <div class="comment-box">
     <form>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
         <p class='or-text'>or</p>
         <%= link_to '削除', '#', class:'item-destroy', method: :delete %>
       <% elsif user_signed_in? %>
-          <%= link_to '購入画面に進む', item_purchases_path(@item) ,class:"item-red-btn"%>
+          <%= link_to '購入画面に進む', item_orders_path(@item) ,class:"item-red-btn"%>
       <% end %>
     <% end %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
         <p class='or-text'>or</p>
         <%= link_to '削除', '#', class:'item-destroy', method: :delete %>
       <% elsif user_signed_in? %>
-          <%= link_to '購入画面に進む', item_orders_path(@item) ,class:"item-red-btn"%>
+          <%= link_to '購入画面に進む', '#' ,class:"item-red-btn"%>
       <% end %>
     <% end %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -7,7 +7,7 @@
     </h2>
     <div class='item-img-content'>
       <%= image_tag @item.image ,class:"item-box-img" %>
-      <% if Order.find_by(item_id: @item.id) %>
+      <% if @item.order %>
         <div class='sold-out'>
           <span>Sold Out!!</span>
         </div>


### PR DESCRIPTION
# What
商品詳細表示機能の実装。

# Why
商品詳細ページに遷移し、アクセスしたユーザーによって表示される情報を変えるため。

【ログアウト状態で商品詳細ページに移動でき、編集、削除、購入ボタンが表示されない】
https://gyazo.com/a9c649df3fa1a635fb0eb5ab6b360992
【商品を出品したユーザーで商品詳細ページに移動でき、編集、削除ボタンが表示される】
https://gyazo.com/2b3bd602002d807a45df5cdf0b81fa04
【商品を出品した以外のユーザーで商品詳細ページに移動でき、購入ボタンが表示される】
https://gyazo.com/b710a01a5373601eec820e1674aca146